### PR TITLE
Multi category settings

### DIFF
--- a/source/api.py
+++ b/source/api.py
@@ -149,6 +149,7 @@ def getFocusDifferenceLevel():
 	return globalVars.focusDifferenceLevel
 
 def getFocusAncestors():
+	"""An array of NVDAObjects that are all parents of the object which currently has focus"""
 	return globalVars.focusAncestors
 
 def getMouseObject():

--- a/source/appModules/nvda.py
+++ b/source/appModules/nvda.py
@@ -10,7 +10,10 @@ import controlTypes
 import versionInfo
 from NVDAObjects.IAccessible import IAccessible
 import gui
+import speech
+import braille
 import config
+from logHandler import log
 
 nvdaMenuIaIdentity = None
 
@@ -28,6 +31,13 @@ class NvdaDialog(IAccessible):
 			return self.presType_content
 		return presType
 
+class NvdaSettingsCategoryPanel(IAccessible):
+
+	def event_nameChange(self):
+		if True and self in api.getFocusAncestors():
+			speech.speakObjectProperties(self, name=True, reason=controlTypes.REASON_CHANGE)
+		braille.handler.handleUpdate(self)
+
 class AppModule(appModuleHandler.AppModule):
 
 	def isNvdaMenu(self, obj):
@@ -41,6 +51,15 @@ class AppModule(appModuleHandler.AppModule):
 		# nvdaMenuIaIdentity is True, so the next menu we encounter is the NVDA menu.
 		if obj.role == controlTypes.ROLE_POPUPMENU:
 			nvdaMenuIaIdentity = obj.IAccessibleIdentity
+			return True
+		return False
+
+	def isNvdaSettingsCategoryPanel(self, obj):
+		controlId = obj.windowControlID
+		from gui.settingsDialogs import NvdaSettingsCategoryPanelId
+		if not isinstance(obj, IAccessible):
+			return False
+		if controlId == NvdaSettingsCategoryPanelId:
 			return True
 		return False
 
@@ -66,3 +85,5 @@ class AppModule(appModuleHandler.AppModule):
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
 		if obj.windowClassName == "#32770" and obj.role == controlTypes.ROLE_DIALOG:
 			clsList.insert(0, NvdaDialog)
+		if self.isNvdaSettingsCategoryPanel(obj):
+			clsList.insert(0, NvdaSettingsCategoryPanel)

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -380,11 +380,11 @@ class MultiCategorySettingsDialog(SettingsDialog):
 		self.container.Freeze()
 		if oldCat:
 			oldCat.onPanelDeactivated()
-		self.currentCategory = newCat
-		newCat.onPanelActivated()
-		# set the label for the container, this is exposed via the Name property on an NVDAObject
+		# set the label for the container as soon as possible, this is exposed via the Name property on an NVDAObject
 		# Translators: This is the label for a category within the settings dialog. It is announced when the user presses `ctl+tab` or `ctrl+shift+tab` while focus is on a control withing the NVDA settings dialog. The %s will be replaced with the name of the panel (eg: General, Speech, Braille, etc)
 		self.container.SetLabel(_("%s Settings Category")%newCat.title)
+		self.currentCategory = newCat
+		newCat.onPanelActivated()
 		# call Layout and SetupScrolling on the container to make sure that the controls apear in their expected locations.
 		self.container.Layout()
 		self.container.SetupScrolling()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -605,8 +605,9 @@ class SpeechSettingsPanel(SettingsPanel):
 		self.synthNameCtrl.SetLabel(synthDesc)
 
 	def onPanelActivated(self):
-		super(SpeechSettingsPanel,self).onPanelActivated()
+		# call super after all panel updates have been completed, we dont want the panel to show until this is complete.
 		self.voicePanel.onPanelActivated()
+		super(SpeechSettingsPanel,self).onPanelActivated()
 
 	def onPanelDeactivated(self):
 		self.voicePanel.onPanelDeactivated()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -251,8 +251,10 @@ class MultiCategorySettingsDialog(SettingsDialog):
 		@type parent: SettingsPanel
 		"""
 		if initialCategory and not issubclass(initialCategory,SettingsPanel):
+			log.debug("Unable to open category: {}".format(initialCategory), stack_info=True)
 			raise TypeError("initialCategory should be an instance of SettingsPanel")
-		if initialCategory not in self.categoryClasses:
+		if initialCategory and initialCategory not in self.categoryClasses:
+			log.debug("Unable to open category: {}".format(initialCategory), stack_info=True)
 			raise MultiCategorySettingsDialog.CategoryUnavailableError("The provided initial category is not a part of this dialog")
 		self.initialCategory=initialCategory
 		self.currentCategory=None

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -173,7 +173,7 @@ class SettingsPanel(wx.Panel):
 		@type parent: wx.Window
 		"""
 		super(SettingsPanel, self).__init__(parent, wx.ID_ANY)
-		self.mainSizer=wx.StaticBoxSizer(wx.StaticBox(self, label=self.title), wx.VERTICAL)
+		self.mainSizer=wx.BoxSizer(wx.VERTICAL)
 		self.settingsSizer=wx.BoxSizer(wx.VERTICAL)
 		self.makeSettings(self.settingsSizer)
 		self.mainSizer.Add(self.settingsSizer, flag=wx.ALL)
@@ -223,6 +223,10 @@ class SettingsPanel(wx.Panel):
 		event.SetEventObject(self)
 		self.GetEventHandler().ProcessEvent(event)
 
+""" The Id of the category panel in the multi category settings dialog, this is set when the dialog is created
+and returned to None when the dialog is destroyed. This can be used by an AppModule for NVDA to identify and announce
+changes in name for the panel when categories are changed"""
+NvdaSettingsCategoryPanelId = None
 class MultiCategorySettingsDialog(SettingsDialog):
 	"""A settings dialog with multiple settings categories.
 	A multi category settings dialog consists of a tree view with settings categories on the left side, 
@@ -280,7 +284,11 @@ class MultiCategorySettingsDialog(SettingsDialog):
 
 		# Put the settings panel in a scrolledPanel, we dont know how large the settings panels might grow. If they exceed the maximum size,
 		# its important all items can be accessed visually.
-		self.container = scrolledpanel.ScrolledPanel(self, size = (self.MAX_WIDTH,self.MAX_HEIGHT), style = wx.TAB_TRAVERSAL | wx.BORDER_THEME)
+		# Save the ID for the panel, this panel will have its name changed when the categories are changed. This name is exposed via the IAccessibleName
+		# property.
+		global NvdaSettingsCategoryPanelId
+		NvdaSettingsCategoryPanelId = wx.NewId()
+		self.container = scrolledpanel.ScrolledPanel(self, id=NvdaSettingsCategoryPanelId, size = (self.MAX_WIDTH,self.MAX_HEIGHT), style = wx.TAB_TRAVERSAL | wx.BORDER_THEME)
 		self.containerSizer = wx.BoxSizer(wx.VERTICAL)
 		panelWidths=[]
 		panelHeights=[]
@@ -323,6 +331,11 @@ class MultiCategorySettingsDialog(SettingsDialog):
 			self.container.SetFocus()
 		else:
 			self.categoryTree.SetFocus()
+
+	def Destroy(self):
+		global NvdaSettingsCategoryPanelId
+		NvdaSettingsCategoryPanelId = None
+		super(MultiCategorySettingsDialog, self).Destroy()
 
 	def onCharHook(self,evt):
 		"""Listens for keyboard input and switches panels for control+tab"""
@@ -369,6 +382,9 @@ class MultiCategorySettingsDialog(SettingsDialog):
 			oldCat.onPanelDeactivated()
 		self.currentCategory = newCat
 		newCat.onPanelActivated()
+		# set the label for the container, this is exposed via the Name property on an NVDAObject
+		# Translators: This is the label for a category within the settings dialog. It is announced when the user presses `ctl+tab` or `ctrl+shift+tab` while focus is on a control withing the NVDA settings dialog. The %s will be replaced with the name of the panel (eg: General, Speech, Braille, etc)
+		self.container.SetLabel(_("%s Settings Category")%newCat.title)
 		# call Layout and SetupScrolling on the container to make sure that the controls apear in their expected locations.
 		self.container.Layout()
 		self.container.SetupScrolling()


### PR DESCRIPTION
This PR proposes using the NVDA app module to announce category changes in the multi category settings dialog.
- This should only be announced when the focus is on the category pane, we don't want to double announce when changing through the treeview.

### Known issues
I have found this isn't working ONLY for the Braille settings category. I don't know why exactly, but when there are more than 5 `wx.Choice` controls the event isn't caught. I haven't confirmed that the nameChange event is created.