### PR TITLE
Lazy init the settings panels

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -336,7 +336,7 @@ class MultiCategorySettingsDialog(SettingsDialog):
 		if not panel:
 			try:
 				cls = self.categoryClasses[catId]
-			except KeyError:
+			except IndexError:
 				raise ValueError("Unable to create panel for unknown category ID: {}".format(catId))
 			panel = cls(parent=self.container)
 			panel.Hide()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -615,7 +615,7 @@ class SpeechSettingsPanel(SettingsPanel):
 	def makeSettings(self, settingsSizer):
 		settingsSizerHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
 		# Translators: A label for the synthesizer on the speech panel.
-		synthLabel = _("&Synthesizer:")
+		synthLabel = _("&Synthesizer")
 		synthGroup = guiHelper.BoxSizerHelper(self, sizer=wx.StaticBoxSizer(wx.StaticBox(self, label=synthLabel), wx.HORIZONTAL))
 		settingsSizerHelper.addItem(synthGroup)
 
@@ -1910,7 +1910,7 @@ class BrailleSettingsPanel(SettingsPanel):
 	def makeSettings(self, settingsSizer):
 		settingsSizerHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
 		# Translators: A label for the braille display on the braille panel.
-		displayLabel = _("Braille &display:")
+		displayLabel = _("Braille &display")
 		displayGroup = guiHelper.BoxSizerHelper(self, sizer=wx.StaticBoxSizer(wx.StaticBox(self, label=displayLabel), wx.HORIZONTAL))
 		settingsSizerHelper.addItem(displayGroup)
 		


### PR DESCRIPTION
Lazy initialisation of the settings panels.

Explanation:
`categoryListItems` holds a dictionary, the key is the panel title and the value is the instance. If a panel is not in there, then `titleToClassMap` is used to instantiate one which has a key of panel title and a value of the class type.

After this modification I was not able to reproduce the warning about the panel being too wide. I will be interested to see if that continues for Mick.