### PR TITLE
Make the multicategory dialog resizable

### DIFF
--- a/source/appModules/nvda.py
+++ b/source/appModules/nvda.py
@@ -45,7 +45,7 @@ class NvdaSettingsCategoryPanel(IAccessible):
 	@classmethod
 	def _handlePossibleProfileSwitch(cls):
 		from gui.settingsDialogs import NvdaSettingsDialogActiveConfigProfile as newProfile
-		if (cls.oldProfile and newProfile and newProfile != cls.oldProfile:
+		if (cls.oldProfile and newProfile and newProfile != cls.oldProfile):
 			# Translators: A message announcing what configuration profile is currently being edited.
 			speech.speakMessage(_("Editing profile {profile}").format(profile=newProfile))
 		cls.oldProfile = newProfile

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -289,7 +289,7 @@ class MultiCategorySettingsDialog(SettingsDialog):
 	# Initial / min size for the dialog. This size was chosen as a medium fit, so the
 	# smaller settings panels are not surrounded by too much space but most of
 	# the panels fit. Vertical scrolling is acceptable. Horizontal scrolling less
-	# so, the width was choosen to eliminate horizontal scroll bars. If a panel
+	# so, the width was chosen to eliminate horizontal scroll bars. If a panel
 	# exceeds the the initial width a debugWarning will be added to the log.
 	MIN_SIZE = (1000, 600)
 
@@ -439,15 +439,16 @@ class MultiCategorySettingsDialog(SettingsDialog):
 
 	def _doCategoryChange(self, newCatId):
 		oldCat = self.currentCategory
-		# Freeze and Thaw are called to stop visual artefacts while the GUI
+		# Freeze and Thaw are called to stop visual artifact's while the GUI
 		# is being rebuilt. Without this, the controls can sometimes be seen being
 		# added.
 		self.container.Freeze()
 		try:
 			newCat = self._getCategoryPanel(newCatId)
 		except ValueError as e:
-			newCatTitle = self.catListCtrl.GetItemText(newIndex)
+			newCatTitle = self.catListCtrl.GetItemText(newCatId)
 			log.error("Unable to change to category: {}".format(newCatTitle), exc_info=e)
+			return
 		if oldCat:
 			oldCat.onPanelDeactivated()
 		self.currentCategory = newCat


### PR DESCRIPTION
This PR aims to address the GUI layout issues when a user has scaling set.

I have not been able to find a way to query the scaling factor via wxPython, it seems that this is still in development and is not yet available even in wxPython 4.  Rather than scale the size of the dialog, this PR makes the dialog resizable, so that in the event of it being too big or too small, a user can resize it to fit the content appropriately.

The intention is to only make the Multi Settings dialog resizable, other dialogs will need to be tested and have layout issues fixed in order to make them resizable in the future.

