### PR TITLE
Multi category settings

### DIFF
--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -105,7 +105,7 @@ class SettingsDialog(wx.Dialog):
 		windowStyle = wx.DEFAULT_DIALOG_STYLE | (wx.RESIZE_BORDER if resizeable else 0)
 		super(SettingsDialog, self).__init__(parent, title=self.title, style=windowStyle)
 
-		# the parent window must be constructed before we can get the handle.
+		# the wx.Window must be constructed before we can get the handle.
 		import windowUtils
 		self.scaleFactor = windowUtils.getWindowScalingFactor(self.GetHandle())
 
@@ -174,7 +174,7 @@ class SettingsDialog(wx.Dialog):
 
 	def scaleSize(self, size):
 		"""Helper method to scale a size using the logical DPI
-		@param size: The size (x,y) to scale
+		@param size: The size (x,y) as a tuple to scale
 		@returns: The scaled size (scaled_X, scaled_Y)"""
 		return (self.scaleFactor * size[0], self.scaleFactor * size[1])
 
@@ -321,7 +321,7 @@ class MultiCategorySettingsDialog(SettingsDialog):
 	# so, the width was chosen to eliminate horizontal scroll bars. If a panel
 	# exceeds the the initial width a debugWarning will be added to the log.
 	INITIAL_SIZE = (800, 480)
-	MIN_SIZE = (470, 240) # Min height to show the buttons.
+	MIN_SIZE = (470, 240) # Min height required to show the OK, Cancel, Apply buttons
 
 	def makeSettings(self, settingsSizer):
 		sHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
@@ -332,10 +332,10 @@ class MultiCategorySettingsDialog(SettingsDialog):
 		categoriesLabel = wx.StaticText(self, label=categoriesLabelText)
 
 		# since the categories list and the container both expand in height, the y
-		# portion is essentially a "min" height
-		# These sizes are set manually so that the initial proportions within the dialog look correct. Otherwise the
-		# proportion arguments (as given to the gridBagSizer.AddGrowableColumn) are used. We want the proportion argument
-		# to be used for resizing, but not the initial size.
+		# portion is essentially a "min" height.
+		# These sizes are set manually so that the initial proportions within the dialog look correct. If these sizes are
+		# not given, then I believe the proportion arguments (as given to the gridBagSizer.AddGrowableColumn) are used
+		# to set their relative sizes. We want the proportion argument to be used for resizing, but not the initial size.
 		catListDim = (150, 10)
 		catListDim = self.scaleSize(catListDim)
 
@@ -353,7 +353,7 @@ class MultiCategorySettingsDialog(SettingsDialog):
 		# The provided column header is just a placeholder, as it is hidden due to the wx.LC_NO_HEADER style flag.
 		self.catListCtrl.InsertColumn(0,categoriesLabelText)
 
-		# Put the settings panel in a scrolledPanel, we dont know how large the settings panels might grow. If they exceed
+		# Put the settings panel in a scrolledPanel, we don't know how large the settings panels might grow. If they exceed
 		# the maximum size, its important all items can be accessed visually.
 		# Save the ID for the panel, this panel will have its name changed when the categories are changed. This name is
 		# exposed via the IAccessibleName property.
@@ -402,7 +402,7 @@ class MultiCategorySettingsDialog(SettingsDialog):
 		gridBagSizer.Add(self.container, pos=(1,1), flag=wx.EXPAND)
 		# Make the row with the listCtrl and settings panel grow vertically.
 		gridBagSizer.AddGrowableRow(1)
-		# Make the columns with the listCtrl and settings panel grow horizontally.
+		# Make the columns with the listCtrl and settings panel grow horizontally if the dialog is resized.
 		# They should grow 1:3, since the settings panel is much more important, and already wider
 		# than the listCtrl.
 		gridBagSizer.AddGrowableCol(0, proportion=1)
@@ -437,7 +437,7 @@ class MultiCategorySettingsDialog(SettingsDialog):
 
 	def postInit(self):
 		# By default after the dialog is created, focus lands on the button group for wx.Dialogs. However this is not where
-		# we wantfocus. We only want to modify focus after creation (makeSettings), but postInit is also called after
+		# we want focus. We only want to modify focus after creation (makeSettings), but postInit is also called after
 		# onApply, so we reset the setPostInitFocus function.
 		if self.setPostInitFocus:
 			self.setPostInitFocus()

--- a/source/gui/settingsDialogs.py
+++ b/source/gui/settingsDialogs.py
@@ -174,9 +174,11 @@ class SettingsDialog(wx.Dialog):
 
 	def scaleSize(self, size):
 		"""Helper method to scale a size using the logical DPI
-		@param size: The size (x,y) as a tuple to scale
-		@returns: The scaled size (scaled_X, scaled_Y)"""
-		return (self.scaleFactor * size[0], self.scaleFactor * size[1])
+		@param size: The size (x,y) as a tuple or a single numerical type to scale
+		@returns: The scaled size, returned as the same type"""
+		if isinstance(size, tuple):
+			return (self.scaleFactor * size[0], self.scaleFactor * size[1])
+		return self.scaleFactor * size
 
 
 # An event and event binder that will notify the containers that they should
@@ -209,6 +211,9 @@ class SettingsPanel(wx.Panel):
 		if gui._isDebug():
 			startTime = time.time()
 		super(SettingsPanel, self).__init__(parent, wx.ID_ANY)
+		# the wx.Window must be constructed before we can get the handle.
+		import windowUtils
+		self.scaleFactor = windowUtils.getWindowScalingFactor(self.GetHandle())
 		self.mainSizer=wx.BoxSizer(wx.VERTICAL)
 		self.settingsSizer=wx.BoxSizer(wx.VERTICAL)
 		self.makeSettings(self.settingsSizer)
@@ -260,6 +265,14 @@ class SettingsPanel(wx.Panel):
 		event = _RWLayoutNeededEvent(self.GetId())
 		event.SetEventObject(self)
 		self.GetEventHandler().ProcessEvent(event)
+
+	def scaleSize(self, size):
+		"""Helper method to scale a size using the logical DPI
+		@param size: The size (x,y) as a tuple or a single numerical type to scale
+		@returns: The scaled size, returned as the same type"""
+		if isinstance(size, tuple):
+			return (self.scaleFactor * size[0], self.scaleFactor * size[1])
+		return self.scaleFactor * size
 
 class MultiCategorySettingsDialog(SettingsDialog):
 	"""A settings dialog with multiple settings categories.
@@ -339,9 +352,10 @@ class MultiCategorySettingsDialog(SettingsDialog):
 		catListDim = (150, 10)
 		catListDim = self.scaleSize(catListDim)
 
-		containerDim = self.scaleSize((self.INITIAL_SIZE[0], 10))
-		spaceForBorders = self.scaleSize((20, 10))
-		containerDim = (containerDim[0] - catListDim[0] - spaceForBorders[0], containerDim[1])
+		initialScaledWidth = self.scaleSize(self.INITIAL_SIZE[0])
+		spaceForBorderWidth = self.scaleSize(20)
+		catListWidth = catListDim[0]
+		containerDim = (initialScaledWidth - catListWidth - spaceForBorderWidth, self.scaleSize(10))
 
 		self.catListCtrl = nvdaControls.AutoWidthColumnListCtrl(
 			self,
@@ -721,7 +735,8 @@ class SpeechSettingsPanel(SettingsPanel):
 		# and a vertical scroll bar. This is not neccessary for the single line of text we wish to
 		# display here.
 		synthDesc = getSynth().description
-		self.synthNameCtrl = ExpandoTextCtrl(self, size=(250,-1), value=synthDesc, style=wx.TE_READONLY)
+		self.synthNameCtrl = ExpandoTextCtrl(self, size=(self.scaleSize(250), -1), value=synthDesc, style=wx.TE_READONLY)
+
 		# Translators: This is the label for the button used to change synthesizer,
 		# it appears in the context of a synthesizer group on the speech settings panel.
 		changeSynthBtn = wx.Button(self, label=_("C&hange..."))
@@ -2011,7 +2026,7 @@ class BrailleSettingsPanel(SettingsPanel):
 		settingsSizerHelper.addItem(displayGroup)
 		
 		displayDesc = braille.handler.display.description
-		self.displayNameCtrl = ExpandoTextCtrl(self, size=(250,-1), value=displayDesc, style=wx.TE_READONLY)
+		self.displayNameCtrl = ExpandoTextCtrl(self, size=(self.scaleSize(250), -1), value=displayDesc, style=wx.TE_READONLY)
 		# Translators: This is the label for the button used to change braille display,
 		# it appears in the context of a braille display group on the braille settings panel.
 		changeDisplayBtn = wx.Button(self, label=_("C&hange..."))

--- a/source/windowUtils.py
+++ b/source/windowUtils.py
@@ -118,10 +118,14 @@ def getWindowScalingFactor(window):
 	# For GetDpiForWindow: an invalid hwnd value will result in a return value of 0.
 	# There is little information about what GetDeviceCaps does in the case of a failure for LOGPIXELSX, however,
 	# a value of zero is certainly an error.
-	if winDpi != 0:
-		return winDpi / DEFAULT_DPI_LEVEL
+	if winDpi <= 0:
+		log.debugWarning("Failed to get the DPI for the window, assuming a "
+		                 "DPI of {} and using a scaling of 1.0. The hWnd value "
+		                 "used was: {}".format(DEFAULT_DPI_LEVEL, window))
+		return 1.0
 
-	return 1.0
+	return winDpi / DEFAULT_DPI_LEVEL
+
 
 
 appInstance = ctypes.windll.kernel32.GetModuleHandleW(None)

--- a/source/windowUtils.py
+++ b/source/windowUtils.py
@@ -99,6 +99,11 @@ DEFAULT_DPI_LEVEL = 96.0
 # via the GetDeviceCaps function.
 LOGPIXELSX = 88
 def getWindowScalingFactor(window):
+	"""Gets the logical scaling factor used for the given window handle. This is based off the Dpi reported by windows
+	for the given window handle / divided by the "base" DPI level of 96. Typically this is a result of using the scaling
+	percentage in the windows display settings. 100% is typically 96 DPI, 150% is typically 144 DPI.
+	@param window: a native Windows window handle (hWnd)
+	@returns the logical scaling factor. EG. 1.0 if the window DPI level is 96, 1.5 if the window DPI level is 144"""
 	user32 = ctypes.windll.user32
 	try:
 		winDpi = user32.GetDpiForWindow(window)

--- a/source/windowUtils.py
+++ b/source/windowUtils.py
@@ -108,12 +108,16 @@ def getWindowScalingFactor(window):
 	try:
 		winDpi = user32.GetDpiForWindow(window)
 	except:
+		log.debug("GetDpiForWindow failed, using GetDeviceCaps instead")
 		dc = user32.GetDC(window)
 		winDpi = ctypes.windll.gdi32.GetDeviceCaps(dc, LOGPIXELSX)
 		ret = user32.ReleaseDC(window, dc)
 		if ret != 1:
-			log.ERROR("Unable to release the device context.")
+			log.error("Unable to release the device context.")
 
+	# For GetDpiForWindow: an invalid hwnd value will result in a return value of 0.
+	# There is little information about what GetDeviceCaps does in the case of a failure for LOGPIXELSX, however,
+	# a value of zero is certainly an error.
 	if winDpi != 0:
 		return winDpi / DEFAULT_DPI_LEVEL
 

--- a/source/windowUtils.py
+++ b/source/windowUtils.py
@@ -94,6 +94,27 @@ def physicalToLogicalPoint(window, x, y):
 	_physicalToLogicalPoint(window, ctypes.byref(point))
 	return point.x, point.y
 
+DEFAULT_DPI_LEVEL = 96.0
+# The constant (defined in winGdi.h) to get the number of logical pixels per inch on the x axis
+# via the GetDeviceCaps function.
+LOGPIXELSX = 88
+def getWindowScalingFactor(window):
+	user32 = ctypes.windll.user32
+	try:
+		winDpi = user32.GetDpiForWindow(window)
+	except:
+		dc = user32.GetDC(window)
+		winDpi = ctypes.windll.gdi32.GetDeviceCaps(dc, LOGPIXELSX)
+		ret = user32.ReleaseDC(window, dc)
+		if ret != 1:
+			log.ERROR("Unable to release the device context.")
+
+	if winDpi != 0:
+		return winDpi / DEFAULT_DPI_LEVEL
+
+	return 1.0
+
+
 appInstance = ctypes.windll.kernel32.GetModuleHandleW(None)
 class CustomWindow(object):
 	"""Base class to enable simple implementation of custom windows.


### PR DESCRIPTION
There were a few issues with scaling / positioning of the settings dialog. I could not find a way to address this using WX (though https://github.com/wxWidgets/wxWidgets/pull/334 looks promising) instead, I have used windows API's to get the scale factor to scale hardcoded sizes.
I use `GetDpiForWindow` which is only available on Windows 10 build 1607 and later, and fallback to `GetDeviceCaps` which is available on Windows 7 and later.

Notice that the default size has changed, this is because I initially set this size while my scaling was set to 125%.

## Testing:
I have tried:
* Windows 10 build 1709 on a 1920x1080 monitor at 100%, 125%, 175%
* Windows 7 with SP1 VM with various monitor sizes and scalings.

## Known Issues:
The maximum size of the window is not limited, with a scaling factor high enough, the dialog can be larger than the available screen space.  In reality, I don't expect this to be a problem, and if it is, it will be a problem for several other NVDA dialogs as well. When testing this scenario in a Windows 7 VM, the Ok/Cancel button group was visible, and the resizing handle in the bottom right corner. I was able to shrink the dialog.
 