### PR TITLE
Thread name logging: Generalize logging of full qualified names (#10259)

### DIFF
--- a/source/_UIAHandler.py
+++ b/source/_UIAHandler.py
@@ -174,7 +174,7 @@ class UIAHandler(COMObject):
 		self.MTAThreadStopEvent=threading.Event()
 		self.MTAThreadInitException=None
 		self.MTAThread = threading.Thread(
-			name="UIAHandler.MTAThread",
+			name=f"{self.__class__.__module__}.{self.__class__.__qualname__}.MTAThread",
 			target=self.MTAThreadFunc
 		)
 		self.MTAThread.daemon=True

--- a/source/braille.py
+++ b/source/braille.py
@@ -2031,7 +2031,7 @@ class _BgThread:
 			return
 		cls.queuedWriteLock = threading.Lock()
 		thread = cls.thread = threading.Thread(
-			name="braille._BgThread",
+			name=f"{cls.__module__}.{cls.__qualname__}",
 			target=cls.func
 		)
 		thread.daemon = True

--- a/source/gui/__init__.py
+++ b/source/gui/__init__.py
@@ -889,7 +889,15 @@ class ExecAndPump(threading.Thread):
 	"""Executes the given function with given args and kwargs in a background thread while blocking and pumping in the current thread."""
 
 	def __init__(self,func,*args,**kwargs):
-		self.name = f"{self.__class__.__name__}({func!r})"
+		if hasattr(func, "__qualname__"):  # _FuncPtr doesn't have this
+			if hasattr(func, "__func__"):
+				fname = func.__func__.__module__
+			else:
+				fname = func.__module__
+			fname += f".{func.__qualname__}"
+		else:
+			fname = repr(func)
+		self.name = f"{self.__class__.__module__}.{self.__class__.__qualname__}({fname})"
 		self.func=func
 		self.args=args
 		self.kwargs=kwargs

--- a/source/nvwave.py
+++ b/source/nvwave.py
@@ -400,7 +400,7 @@ def playWaveFile(fileName, asynchronous=True):
 		if fileWavePlayerThread is not None:
 			fileWavePlayerThread.join()
 		fileWavePlayerThread = threading.Thread(
-			name=f"fileWavePlayerThread({os.path.basename(fileName)})",
+			name=f"{__name__}.playWaveFile({os.path.basename(fileName)})",
 			target=fileWavePlayer.idle
 		)
 		fileWavePlayerThread.start()

--- a/source/synthDrivers/_espeak.py
+++ b/source/synthDrivers/_espeak.py
@@ -177,10 +177,8 @@ def callback(wav,numsamples,event):
 		log.error("callback", exc_info=True)
 
 class BgThread(threading.Thread):
-	name = "espeakBgThread"
-
 	def __init__(self):
-		threading.Thread.__init__(self)
+		super().__init__(name=f"{self.__class__.__module__}.{self.__class__.__qualname__}")
 		self.setDaemon(True)
 
 	def run(self):

--- a/source/touchHandler.py
+++ b/source/touchHandler.py
@@ -206,11 +206,9 @@ class TouchInputGesture(inputCore.InputGesture):
 inputCore.registerGestureSource("ts", TouchInputGesture)
 
 class TouchHandler(threading.Thread):
-	name = __name__
-
 	def __init__(self):
 		self.pendingEmitsTimer=gui.NonReEntrantTimer(core.requestPump)
-		super(TouchHandler,self).__init__()
+		super().__init__(name=f"{self.__class__.__module__}.{self.__class__.__qualname__}")
 		self._curTouchMode='object'
 		self.initializedEvent=threading.Event()
 		self.threadExc=None

--- a/source/updateCheck.py
+++ b/source/updateCheck.py
@@ -226,7 +226,7 @@ class UpdateChecker(object):
 		"""Check for an update.
 		"""
 		t = threading.Thread(
-			name=self.__class__.__qualname__,
+			name=f"{self.__class__.__module__}.{self.check.__qualname__}",
 			target=self._bg
 		)
 		t.daemon = True
@@ -584,7 +584,7 @@ class UpdateDownloader(object):
 			parent=gui.mainFrame)
 		self._progressDialog.Raise()
 		t = threading.Thread(
-			name=self.__class__.__qualname__,
+			name=f"{self.__class__.__module__}.{self.start.__qualname__}",
 			target=self._bg
 		)
 		t.daemon = True

--- a/source/virtualBuffers/__init__.py
+++ b/source/virtualBuffers/__init__.py
@@ -434,7 +434,7 @@ class VirtualBuffer(browseMode.BrowseModeDocumentTreeInterceptor):
 		self.isLoading = True
 		self._loadProgressCallLater = wx.CallLater(1000, self._loadProgress)
 		threading.Thread(
-			name=f"{self.__class__.__qualname__}BufferLoader",
+			name=f"{self.__class__.__module__}.{self.loadBuffer.__qualname__}",
 			target=self._loadBuffer).start(
 		)
 

--- a/source/visionEnhancementProviders/NVDAHighlighter.py
+++ b/source/visionEnhancementProviders/NVDAHighlighter.py
@@ -242,7 +242,7 @@ class VisionEnhancementProvider(vision.providerBase.VisionEnhancementProvider):
 		winGDI.gdiPlusInitialize()
 		self.window = None
 		self._highlighterThread = threading.Thread(
-			name="NVDAHighlighterThread",
+			name=f"{self.__class__.__module__}.{self.__class__.__qualname__}",
 			target=self._run
 		)
 		self._highlighterThread.daemon = True

--- a/source/watchdog.py
+++ b/source/watchdog.py
@@ -210,7 +210,7 @@ def initialize():
 	# Handle cancelled SendMessage calls.
 	NVDAHelper._setDllFuncPointer(NVDAHelper.localLib, "_notifySendMessageCancelled", _notifySendMessageCancelled)
 	_watcherThread = threading.Thread(
-		name="watcherThread",
+		name="__name__",
 		target=_watcher
 	)
 	alive()
@@ -257,7 +257,15 @@ class CancellableCallThread(threading.Thread):
 		self.isUsable = True
 
 	def execute(self, func, *args, pumpMessages=True, **kwargs):
-		self.name = f"{self.__class__.__name__}({func!r})"
+		if hasattr(func, "__qualname__"):  # _FuncPtr doesn't have this
+			if hasattr(func, "__func__"):
+				fname = func.__func__.__module__
+			else:
+				fname = func.__module__
+			fname += f".{func.__qualname__}"
+		else:
+			fname = repr(func)
+		self.name = f"{self.__class__.__module__}.{self.execute.__qualname__}({fname})"
 		# Don't even bother making the call if the core is already dead.
 		if isAttemptingRecovery:
 			raise CallCancelled

--- a/source/watchdog.py
+++ b/source/watchdog.py
@@ -210,7 +210,7 @@ def initialize():
 	# Handle cancelled SendMessage calls.
 	NVDAHelper._setDllFuncPointer(NVDAHelper.localLib, "_notifySendMessageCancelled", _notifySendMessageCancelled)
 	_watcherThread = threading.Thread(
-		name="__name__",
+		name=__name__,
 		target=_watcher
 	)
 	alive()


### PR DESCRIPTION
<!--
Please fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->

### Link to issue number:

NVDA PR #10259)

### Summary of the issue:

First of all, thanks a lot for your work on PR #10259, it will most likely save us a lot of headaches once merged!
Reviewing your code lead me to discover [PEP 3155](https://www.python.org/dev/peps/pep-3155/) which I did not notice before.
I'd like to step a bit further from your use of `__qualname__` and generalize the use of fully qualified names as thread names.
For one thing, I feel it uniformises the log output.
Secondly, I think it would help us debug cumbersome situations such as when add-ons performed monkey-patching into NVDA core.

### Description of how this pull request fixes the issue:

Generalize patterns of the form:
`name = f"{self.__class__.__module__}.{self.__class__.__qualname__}"`

### Testing performed:

Ran a source copy in debug mode to check the log output.
This led me by the way to discover `_FuncPtr` holds no `__qualname__`, while lambdas do.

### Known issues with pull request:

The code is a little more verbose.
It might benefit from a little factorization, but I'm not sure we currently have a nice candidate location for this, and there is quite a few specific corner-cases.

### Change log entry:

N/A